### PR TITLE
feat: IssueRepository インターフェースを定義 (#5)

### DIFF
--- a/src/domain/issue/repository.ts
+++ b/src/domain/issue/repository.ts
@@ -1,0 +1,15 @@
+import type { Issue } from "./entity.js";
+
+export type IssueFilter = {
+	status?: "open" | "closed";
+	limit?: number;
+	offset?: number;
+};
+
+export interface IssueRepository {
+	save(issue: Issue): Promise<Issue>; // 新規保存
+	findById(id: string): Promise<Issue | null>; // ID検索
+	findAll(filter?: IssueFilter): Promise<Issue[]>; // 複数件検索
+	update(issue: Issue): Promise<Issue>; // 更新
+	delete(id: string): Promise<void>; // 削除
+}


### PR DESCRIPTION
## 概要

ドメイン層にIssueRepositoryインターフェースを定義。CRUD操作の契約をドメイン層に置き、依存性逆転を実現する。

Closes #5

## 変更内容

- `src/domain/issue/repository.ts`: IssueRepository interface（save, findById, findAll, update, delete）
- `IssueFilter` 型を定義（status, limit, offset によるフィルタリング）

## 確認方法

```bash
pnpm tsc --noEmit   # 型チェック
pnpm vitest run     # テスト実行
```

## チェックリスト

- [x] `pnpm tsc` エラー0
- [x] `pnpm check` エラー0
- [x] `pnpm test` 全パス
- [x] 依存方向が正しい（外→内）

🤖 Generated with [Claude Code](https://claude.com/claude-code)