### PR TITLE
feat: CreateIssueUsecase を実装し単体テストを追加 (#7)

### DIFF
--- a/src/domain/issue/errors.ts
+++ b/src/domain/issue/errors.ts
@@ -4,3 +4,10 @@ export class IssueNotFoundError extends Error {
 		this.name = "IssueNotFoundError";
 	}
 }
+
+export class InvalidIssueTitleError extends Error {
+	constructor() {
+		super("titleは空にできません");
+		this.name = "InvalidIssueTitleError";
+	}
+}

--- a/src/usecase/issue/createIssue.ts
+++ b/src/usecase/issue/createIssue.ts
@@ -1,0 +1,27 @@
+import { randomUUID } from "node:crypto";
+import type { Issue } from "../../domain/issue/entity.js";
+import { InvalidIssueTitleError } from "../../domain/issue/errors.js";
+import type { IssueRepository } from "../../domain/issue/repository.js";
+
+export class CreateIssueUsecase {
+	constructor(private repository: IssueRepository) {}
+
+	async execute(input: {
+		title: string;
+		description?: string;
+	}): Promise<Issue> {
+		const title = input.title.trim();
+		if (!title) throw new InvalidIssueTitleError();
+
+		const newIssue: Issue = {
+			id: randomUUID(),
+			title: title,
+			description: input.description ?? "",
+			status: "open",
+			createdAt: new Date(),
+			updatedAt: new Date(),
+		};
+
+		return this.repository.save(newIssue);
+	}
+}

--- a/tests/usecase/issue/createIssue.test.ts
+++ b/tests/usecase/issue/createIssue.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "vitest";
+import { CreateIssueUsecase } from "../../../src/usecase/issue/createIssue.js";
+import { FakeIssueRepository } from "../../fakes/fakeIssueRepository.js";
+
+describe("CreateIssueUsecase", () => {
+	test("titleを渡してIssueが返ること、status が openであること", async () => {
+		const repo = new FakeIssueRepository();
+		const usecase = new CreateIssueUsecase(repo);
+		const issue = {
+			title: "test",
+			description: "test",
+		};
+		const result = await usecase.execute(issue);
+		expect(result.id).toBeDefined();
+		expect(result.title).toBe("test");
+		expect(result.description).toBe("test");
+		expect(result.status).toBe("open");
+	});
+
+	test("title が空文字でエラーが throw されること", async () => {
+		const repo = new FakeIssueRepository();
+		const usecase = new CreateIssueUsecase(repo);
+		const issue = {
+			title: "",
+		};
+		await expect(usecase.execute(issue)).rejects.toThrow();
+	});
+});


### PR DESCRIPTION
## 概要

<!-- このPRで何をしたか、1-3行で -->

Closes #<!-- Issue番号 -->

## 変更内容

<!-- 主な変更点を箇条書きで -->

-

## 確認方法

<!-- 動作確認の手順。curl コマンド、テスト実行コマンド等 -->

```bash

```

## チェックリスト

- [ ] `pnpm tsc` エラー0
- [ ] `pnpm check` エラー0
- [ ] `pnpm test` 全パス
- [ ] 依存方向が正しい（外→内）
